### PR TITLE
Adjust Save & Restore Logic

### DIFF
--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -31,7 +31,7 @@ gcode:
 # Per tool spool config
 [gcode_macro T0]
 rename_existing: T0.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T0"].spool_id %}
   {% if sid %}
@@ -43,7 +43,7 @@ gcode:
 
 [gcode_macro T1]
 rename_existing: T1.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T1"].spool_id %}
   {% if sid %}
@@ -55,7 +55,7 @@ gcode:
 
 [gcode_macro T2]
 rename_existing: T2.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T2"].spool_id %}
   {% if sid %}
@@ -67,7 +67,7 @@ gcode:
 
 [gcode_macro T3]
 rename_existing: T3.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T3"].spool_id %}
   {% if sid %}

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -22,7 +22,7 @@ gcode:
 gcode:
   {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
   {% for tool in ['T0','T1','T2','T3'] %}
-    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE=\"\"
+    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE="None"
   {% endfor %}
   UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=1
 
@@ -90,7 +90,7 @@ gcode:
       SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
     {% else %}
       #RESPOND PREFIX="🧶" MSG="Clearing spool for {vname}"
-      SAVE_VARIABLE VARIABLE={vname} VALUE=\"\"
+      SAVE_VARIABLE VARIABLE={vname} VALUE="None"
     {% endif %}
   {% endfor %}
 

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -38,6 +38,8 @@ gcode:
   {% set sid = printer["gcode_macro T0"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T0.10001 {rawparams}
 
@@ -48,6 +50,8 @@ gcode:
   {% set sid = printer["gcode_macro T1"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T1.10001 {rawparams}
 
@@ -58,6 +62,8 @@ gcode:
   {% set sid = printer["gcode_macro T2"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T2.10001 {rawparams}
 
@@ -68,6 +74,8 @@ gcode:
   {% set sid = printer["gcode_macro T3"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T3.10001 {rawparams}
 

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -2,6 +2,76 @@
 [save_variables]
 filename: ~/printer_data/config/variables.cfg
 
+[gcode_macro SET_ACTIVE_SPOOL_MAPPED]
+description: Activates spool ID based on tool index, optionally using the extruder map for verification.
+gcode:
+  # --- Check if TOOL_INDEX parameter is provided ---
+  {% if not params.TOOL_INDEX is defined %}
+    RESPOND MSG="Error in SET_ACTIVE_SPOOL_MAPPED: Parameter 'TOOL_INDEX' is required."
+    return
+  {% endif %}
+
+  {% set tool_index = params.TOOL_INDEX|int %}
+  {% set spool_macro_name = "" %}
+  {% set map_table_key = 'extruder_map_table' %}
+  
+  # --- Check for existence of the extruder map table (List) ---
+  {% if printer.print_task_config is defined and map_table_key in printer.print_task_config %}
+    {% set map_table = printer.print_task_config[map_table_key] %}
+
+    # Check if the tool_index is a valid index for the map_table list
+    {% if tool_index < 0 or tool_index >= map_table|length %}
+      RESPOND MSG="Error: extruder_map_table list exists but Tool Index {tool_index} is out of range (list size: {map_table|length}). Cannot determine spool macro."
+      return
+    {% endif %}
+    # Use the tool_index directly to get the physical extruder index from the list
+    {% set extruder_index = map_table[tool_index]|int %}
+    # The Spoolman macro name is based on the physical extruder index
+    {% set spool_macro_name = 'T' ~ extruder_index %}
+    
+    RESPOND MSG="Tool Index {tool_index} maps to Extruder Index {extruder_index}."
+
+  {% else %}
+    # Map table does not exist. Use the tool_index directly as the spool macro index (Fallback).
+    {% set spool_macro_name = 'T' ~ tool_index %}
+    
+    RESPOND MSG="extruder_map_table not found. Using Tool Index {tool_index} directly as spool macro name {spool_macro_name}."
+  {% endif %}
+
+  {% set spool_macro_key = 'gcode_macro ' ~ spool_macro_name %}
+  
+  # --- Check if the required spool macro (e.g., T0, T1) exists ---
+  {% if spool_macro_key not in printer %}
+    RESPOND MSG="Error: Spool macro {spool_macro_name} (derived from map/index) not configured."
+    return
+  {% endif %}
+  
+  {% set spool_macro_object = printer[spool_macro_key] %}
+
+  # --- Check if the 'spool_id' variable exists on the macro ---
+  {% if spool_macro_object.spool_id is not defined %}
+    RESPOND MSG="Error: 'spool_id' variable missing in macro {spool_macro_name}."
+    return
+  {% endif %}
+  
+  {% set spool_id_to_set = spool_macro_object.spool_id %}
+  
+  # --- EXECUTION LOGIC ---
+  
+  # Check for a valid spool ID (not 'None' string or None object)
+  {% if spool_id_to_set is defined and spool_id_to_set and spool_id_to_set != "None" %}
+    # Call the main spool setting macro
+    SET_ACTIVE_SPOOL ID={spool_id_to_set}
+    
+    RESPOND MSG="Spool for {spool_macro_name} set to ID: {spool_id_to_set}"
+  {% else %}
+    # Clear the active spool
+    CLEAR_ACTIVE_SPOOL
+    
+    RESPOND MSG="No spool mapped for {spool_macro_name}. Cleared active spool."
+  {% endif %}
+
+
 # main Spool selection macro
 [gcode_macro SET_ACTIVE_SPOOL]
 gcode:
@@ -33,48 +103,28 @@ gcode:
 rename_existing: T0.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T0"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=0
   T0.10001 {rawparams}
 
 [gcode_macro T1]
 rename_existing: T1.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T1"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=1
   T1.10001 {rawparams}
 
 [gcode_macro T2]
 rename_existing: T2.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T2"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=2
   T2.10001 {rawparams}
 
 [gcode_macro T3]
 rename_existing: T3.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T3"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=3
   T3.10001 {rawparams}
 
 [delayed_gcode SAVE_SELECTED_SPOOLS]

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -8,7 +8,6 @@ gcode:
   {% if params.ID is defined %}
     {% set id = params.ID|int %}
     {action_call_remote_method("spoolman_set_active_spool", spool_id=id)}
-    UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
   {% else %}
     {action_respond_info("Parameter 'ID' is required")}
   {% endif %}
@@ -16,7 +15,6 @@ gcode:
 [gcode_macro CLEAR_ACTIVE_SPOOL]
 gcode:
   {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
-  UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
 
 [gcode_macro CLEAR_ALL_SPOOLS]
 gcode:


### PR DESCRIPTION
I ran into a few issues while using this on my machine.

### Restore Issue
Updated `SAVE_SELECTED_SPOOLS` to save `None` when no spool is selected. The initial version was saving `''` to the variables file which caused the restore to fail with the following:

```
05:29:35.694:Unable to parse '' as a literal: invalid syntax (<unknown>, line 0)
05:29:35.695:Script running error
Traceback (most recent call last):
  File "/home/lava/klipper/klippy/extras/gcode_macro.py", line 172, in cmd_SET_GCODE_VARIABLE
    literal = ast.literal_eval(value)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/ast.py", line 64, in literal_eval
  File "/usr/lib/python3.11/ast.py", line 50, in parse
  File "<unknown>", line 0
    
SyntaxError: invalid syntax

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/lava/klipper/klippy/extras/delayed_gcode.py", line 34, in _gcode_timer_event
    self.gcode.run_script(self.timer_gcode.render())
  File "/home/lava/klipper/klippy/gcode.py", line 254, in run_script
    self._process_commands(script.split('\n'), need_ack=False)
  File "/home/lava/klipper/klippy/gcode.py", line 229, in _process_commands
    handler(gcmd)
  File "/home/lava/klipper/klippy/gcode.py", line 144, in <lambda>
    func = lambda params: origfunc(self._get_extended_params(params))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lava/klipper/klippy/gcode.py", line 154, in <lambda>
    handler = lambda gcmd: self._cmd_mux(cmd, gcmd)
                           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lava/klipper/klippy/gcode.py", line 340, in _cmd_mux
    values[key_param](gcmd)
  File "/home/lava/klipper/klippy/extras/gcode_macro.py", line 175, in cmd_SET_GCODE_VARIABLE
    raise gcmd.error("Unable to parse '%s' as a literal: %s" %
gcode.CommandError: Unable to parse '' as a literal: invalid syntax (<unknown>, line 0)
05:29:35.704:Raising exception: id:522 index:0 code:0 oneshot:1 level:3 is_persistent:0, message: Unable to parse '' as a literal: invalid syntax (<unknown>, line 0)
```

### Tool Macros Change
Updated the tool macros to clear the active spool if that tool doesn't have a spool set. This prevents the last spool id from staying active when changing to a tool that doesn't have a spool set.

### Remove Save on Set & Clear
Removed the calls to `SAVE_SELECTED_SPOOLS` from `SET_ACTIVE_SPOOL` and `CLEAR_ALL_SPOOLS`. Fluidd already calls `SET_VARIABLE` when a spool is set on a tool so it seemed excessive to save all the spools each time the active spool was set.