### PR TITLE
Allow spool assignment based on physical tool 

### DIFF
--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -2,6 +2,12 @@
 [save_variables]
 filename: ~/printer_data/config/variables.cfg
 
+[gcode_macro _SPOOLMAN_CFG]
+variable_tools: ['T0','T1','T2','T3']
+gcode:
+  # no g-code, this is just a conveniet "array" because I don't like to repeat my sef.
+  RESPOND PREFIX="🧶" MSG="Nothing to see here"
+
 [gcode_macro SET_ACTIVE_SPOOL_MAPPED]
 description: Activates spool ID based on tool index, optionally using the extruder map for verification.
 gcode:
@@ -86,16 +92,26 @@ gcode:
 gcode:
   {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
 
+# Only touch tools that exist AND actually expose .spool_id
 [gcode_macro CLEAR_ALL_SPOOLS]
 gcode:
   {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
-  {% for tool in ['T0','T1','T2','T3'] %}
-    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE="None"
+
+  RESPOND PREFIX="🧶" MSG="Clearing all spools"
+
+  {% set tools = printer["gcode_macro _SPOOLMAN_CFG"].tools %}
+  {% for tool in tools %}
+    {% set macro = "gcode_macro " ~ tool %}
+    {% if macro in printer and printer[macro].spool_id is defined %}
+      SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE="None"
+    {% endif %}
   {% endfor %}
+
   UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=1
 
 [gcode_macro SAVE_CURRENT_SPOOLS]
 gcode:
+  RESPOND PREFIX="🧶" MSG="Current spools saved"
   UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
 
 # Per tool spool config
@@ -129,10 +145,18 @@ gcode:
 
 [delayed_gcode SAVE_SELECTED_SPOOLS]
 gcode:
-  {% for tool in ['T0','T1','T2','T3'] %}
-    {% set macro = 'gcode_macro ' ~ tool %}
-    {% set sid = printer[macro].spool_id|default("") %}
-    {% set vname = tool|lower ~ '__spool_id' %}
+  {% set tools = printer["gcode_macro _SPOOLMAN_CFG"].tools %}
+
+  {% for tool in tools %}
+    {% set macro = "gcode_macro " ~ tool %}
+    {% set vname = tool|lower ~ "__spool_id" %}
+
+    {% if macro in printer and printer[macro].spool_id is defined %}
+      {% set sid = printer[macro].spool_id|default("") %}
+    {% else %}
+      {% set sid = "" %}
+    {% endif %}
+
     {% if sid != "" %}
       #RESPOND PREFIX="🧶" MSG="Saving spool for {vname}: {sid}"
       SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
@@ -142,11 +166,11 @@ gcode:
     {% endif %}
   {% endfor %}
 
-# Apply spected spool during print
 [delayed_gcode RESTORE_SELECTED_SPOOLS]
 initial_duration: 0.1
 gcode:
   {% set svv = printer.save_variables.variables %}
+  RESPOND PREFIX="🧶" MSG="Restoring spools selection"
   {% for object in printer %}
     {% if object.startswith('gcode_macro ') and printer[object].spool_id is defined %}
       {% set macro = object.replace('gcode_macro ', '') %}

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -109,10 +109,49 @@ gcode:
 
   UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=1
 
+[delayed_gcode SAVE_SELECTED_SPOOLS]
+gcode:
+  {% set tools = printer["gcode_macro _SPOOLMAN_CFG"].tools %}
+
+  {% for tool in tools %}
+    {% set macro = "gcode_macro " ~ tool %}
+    {% set vname = tool|lower ~ "__spool_id" %}
+
+    {% if macro in printer and printer[macro].spool_id is defined %}
+      {% set sid = printer[macro].spool_id|default("") %}
+    {% else %}
+      {% set sid = "" %}
+    {% endif %}
+
+    {% if sid != "" %}
+      #RESPOND PREFIX="🧶" MSG="Saving spool for {vname}: {sid}"
+      SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
+    {% else %}
+      #RESPOND PREFIX="🧶" MSG="Clearing spool for {vname}"
+      SAVE_VARIABLE VARIABLE={vname} VALUE="None"
+    {% endif %}
+  {% endfor %}
+
 [gcode_macro SAVE_CURRENT_SPOOLS]
 gcode:
   RESPOND PREFIX="🧶" MSG="Current spools saved"
   UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
+
+[delayed_gcode RESTORE_SELECTED_SPOOLS]
+initial_duration: 0.1
+gcode:
+  {% set svv = printer.save_variables.variables %}
+  RESPOND PREFIX="🧶" MSG="Restoring spools selection"
+  {% for object in printer %}
+    {% if object.startswith('gcode_macro ') and printer[object].spool_id is defined %}
+      {% set macro = object.replace('gcode_macro ', '') %}
+      {% set var = (macro + '__SPOOL_ID')|lower %}
+      {% if svv[var] is defined %}
+        SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE={svv[var]}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+
 
 # Per tool spool config
 [gcode_macro T0]
@@ -142,41 +181,3 @@ variable_spool_id: None
 gcode:
   SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=3
   T3.10001 {rawparams}
-
-[delayed_gcode SAVE_SELECTED_SPOOLS]
-gcode:
-  {% set tools = printer["gcode_macro _SPOOLMAN_CFG"].tools %}
-
-  {% for tool in tools %}
-    {% set macro = "gcode_macro " ~ tool %}
-    {% set vname = tool|lower ~ "__spool_id" %}
-
-    {% if macro in printer and printer[macro].spool_id is defined %}
-      {% set sid = printer[macro].spool_id|default("") %}
-    {% else %}
-      {% set sid = "" %}
-    {% endif %}
-
-    {% if sid != "" %}
-      #RESPOND PREFIX="🧶" MSG="Saving spool for {vname}: {sid}"
-      SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
-    {% else %}
-      #RESPOND PREFIX="🧶" MSG="Clearing spool for {vname}"
-      SAVE_VARIABLE VARIABLE={vname} VALUE="None"
-    {% endif %}
-  {% endfor %}
-
-[delayed_gcode RESTORE_SELECTED_SPOOLS]
-initial_duration: 0.1
-gcode:
-  {% set svv = printer.save_variables.variables %}
-  RESPOND PREFIX="🧶" MSG="Restoring spools selection"
-  {% for object in printer %}
-    {% if object.startswith('gcode_macro ') and printer[object].spool_id is defined %}
-      {% set macro = object.replace('gcode_macro ', '') %}
-      {% set var = (macro + '__SPOOL_ID')|lower %}
-      {% if svv[var] is defined %}
-        SET_GCODE_VARIABLE MACRO={macro} VARIABLE=spool_id VALUE={svv[var]}
-      {% endif %}
-    {% endif %}
-  {% endfor %}

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -31,7 +31,7 @@ gcode:
 # Per tool spool config
 [gcode_macro T0]
 rename_existing: T0.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T0"].spool_id %}
   {% if sid %}
@@ -43,7 +43,7 @@ gcode:
 
 [gcode_macro T1]
 rename_existing: T1.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T1"].spool_id %}
   {% if sid %}
@@ -55,7 +55,7 @@ gcode:
 
 [gcode_macro T2]
 rename_existing: T2.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T2"].spool_id %}
   {% if sid %}
@@ -67,7 +67,7 @@ gcode:
 
 [gcode_macro T3]
 rename_existing: T3.10001
-variable_spool_id: ""
+variable_spool_id: None
 gcode:
   {% set sid = printer["gcode_macro T3"].spool_id %}
   {% if sid %}

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -22,7 +22,7 @@ gcode:
 gcode:
   {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
   {% for tool in ['T0','T1','T2','T3'] %}
-    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE=\"\"
+    SET_GCODE_VARIABLE MACRO={tool} VARIABLE=spool_id VALUE="None"
   {% endfor %}
   UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=1
 
@@ -90,7 +90,7 @@ gcode:
       SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
     {% else %}
       #RESPOND PREFIX="🧶" MSG="Clearing spool for {vname}"
-      SAVE_VARIABLE VARIABLE={vname} VALUE=\"\"
+      SAVE_VARIABLE VARIABLE={vname} VALUE="None"
     {% endif %}
   {% endfor %}
 

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -38,6 +38,8 @@ gcode:
   {% set sid = printer["gcode_macro T0"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T0.10001 {rawparams}
 
@@ -48,6 +50,8 @@ gcode:
   {% set sid = printer["gcode_macro T1"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T1.10001 {rawparams}
 
@@ -58,6 +62,8 @@ gcode:
   {% set sid = printer["gcode_macro T2"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T2.10001 {rawparams}
 
@@ -68,6 +74,8 @@ gcode:
   {% set sid = printer["gcode_macro T3"].spool_id %}
   {% if sid %}
     SET_ACTIVE_SPOOL ID={sid}
+  {% else %}
+    CLEAR_ACTIVE_SPOOL
   {% endif %}
   T3.10001 {rawparams}
 

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -2,6 +2,76 @@
 [save_variables]
 filename: ~/printer_data/config/variables.cfg
 
+[gcode_macro SET_ACTIVE_SPOOL_MAPPED]
+description: Activates spool ID based on tool index, optionally using the extruder map for verification.
+gcode:
+  # --- Check if TOOL_INDEX parameter is provided ---
+  {% if not params.TOOL_INDEX is defined %}
+    RESPOND MSG="Error in SET_ACTIVE_SPOOL_MAPPED: Parameter 'TOOL_INDEX' is required."
+    return
+  {% endif %}
+
+  {% set tool_index = params.TOOL_INDEX|int %}
+  {% set spool_macro_name = "" %}
+  {% set map_table_key = 'extruder_map_table' %}
+  
+  # --- Check for existence of the extruder map table (List) ---
+  {% if printer.print_task_config is defined and map_table_key in printer.print_task_config %}
+    {% set map_table = printer.print_task_config[map_table_key] %}
+
+    # Check if the tool_index is a valid index for the map_table list
+    {% if tool_index < 0 or tool_index >= map_table|length %}
+      RESPOND MSG="Error: extruder_map_table list exists but Tool Index {tool_index} is out of range (list size: {map_table|length}). Cannot determine spool macro."
+      return
+    {% endif %}
+    # Use the tool_index directly to get the physical extruder index from the list
+    {% set extruder_index = map_table[tool_index]|int %}
+    # The Spoolman macro name is based on the physical extruder index
+    {% set spool_macro_name = 'T' ~ extruder_index %}
+    
+    RESPOND MSG="Tool Index {tool_index} maps to Extruder Index {extruder_index}."
+
+  {% else %}
+    # Map table does not exist. Use the tool_index directly as the spool macro index (Fallback).
+    {% set spool_macro_name = 'T' ~ tool_index %}
+    
+    RESPOND MSG="extruder_map_table not found. Using Tool Index {tool_index} directly as spool macro name {spool_macro_name}."
+  {% endif %}
+
+  {% set spool_macro_key = 'gcode_macro ' ~ spool_macro_name %}
+  
+  # --- Check if the required spool macro (e.g., T0, T1) exists ---
+  {% if spool_macro_key not in printer %}
+    RESPOND MSG="Error: Spool macro {spool_macro_name} (derived from map/index) not configured."
+    return
+  {% endif %}
+  
+  {% set spool_macro_object = printer[spool_macro_key] %}
+
+  # --- Check if the 'spool_id' variable exists on the macro ---
+  {% if spool_macro_object.spool_id is not defined %}
+    RESPOND MSG="Error: 'spool_id' variable missing in macro {spool_macro_name}."
+    return
+  {% endif %}
+  
+  {% set spool_id_to_set = spool_macro_object.spool_id %}
+  
+  # --- EXECUTION LOGIC ---
+  
+  # Check for a valid spool ID (not 'None' string or None object)
+  {% if spool_id_to_set is defined and spool_id_to_set and spool_id_to_set != "None" %}
+    # Call the main spool setting macro
+    SET_ACTIVE_SPOOL ID={spool_id_to_set}
+    
+    RESPOND MSG="Spool for {spool_macro_name} set to ID: {spool_id_to_set}"
+  {% else %}
+    # Clear the active spool
+    CLEAR_ACTIVE_SPOOL
+    
+    RESPOND MSG="No spool mapped for {spool_macro_name}. Cleared active spool."
+  {% endif %}
+
+
 # main Spool selection macro
 [gcode_macro SET_ACTIVE_SPOOL]
 gcode:
@@ -33,48 +103,28 @@ gcode:
 rename_existing: T0.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T0"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=0
   T0.10001 {rawparams}
 
 [gcode_macro T1]
 rename_existing: T1.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T1"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=1
   T1.10001 {rawparams}
 
 [gcode_macro T2]
 rename_existing: T2.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T2"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=2
   T2.10001 {rawparams}
 
 [gcode_macro T3]
 rename_existing: T3.10001
 variable_spool_id: None
 gcode:
-  {% set sid = printer["gcode_macro T3"].spool_id %}
-  {% if sid %}
-    SET_ACTIVE_SPOOL ID={sid}
-  {% else %}
-    CLEAR_ACTIVE_SPOOL
-  {% endif %}
+  SET_ACTIVE_SPOOL_MAPPED TOOL_INDEX=3
   T3.10001 {rawparams}
 
 [delayed_gcode SAVE_SELECTED_SPOOLS]

--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -8,7 +8,6 @@ gcode:
   {% if params.ID is defined %}
     {% set id = params.ID|int %}
     {action_call_remote_method("spoolman_set_active_spool", spool_id=id)}
-    UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
   {% else %}
     {action_respond_info("Parameter 'ID' is required")}
   {% endif %}
@@ -16,7 +15,6 @@ gcode:
 [gcode_macro CLEAR_ACTIVE_SPOOL]
 gcode:
   {action_call_remote_method("spoolman_set_active_spool", spool_id=None)}
-  UPDATE_DELAYED_GCODE ID=SAVE_SELECTED_SPOOLS DURATION=0.01
 
 [gcode_macro CLEAR_ALL_SPOOLS]
 gcode:


### PR DESCRIPTION
Added support for physical-to-virtual extruder mapping and fixes a bug that prevented spool restoration from working correctly.

#### 1. **Extruder Map Table Support** (`SET_ACTIVE_SPOOL_MAPPED`)
Added a new macro that supports virtual tool indices mapped to physical extruders via `printer.print_task_config.extruder_map_table`. This enables proper spool tracking when using virtual tool remapping.

- When `extruder_map_table` exists: Maps virtual tool index → physical extruder → correct spool
- Fallback behavior: Uses tool index directly (backwards compatible)
- Comprehensive error handling with clear RESPOND messages

#### 2. **Fix: Empty String Parsing Error**
Fixed a bug where empty strings caused restore failures:
gcode.CommandError: Unable to parse '' as a literal: invalid syntax (, line 0)

Use `"None"` (string) instead of `""` for unset spools in saved variables, and `None` (Python object) as default for `variable_spool_id`.

#### 3. **Configuration Changes**
- Changed `variable_tools` to a Python list `['T0','T1','T2','T3']` instead of comma-separated string (easier to iterate)
- Configured for 4 tools by default (expandable to 32 if needed)
- Added robustness checks in `CLEAR_ALL_SPOOLS` and `SAVE_SELECTED_SPOOLS` to only process tools that exist and have `spool_id` defined
