### PR TITLE
fix: prevent SAVE_VARIABLE crash with empty string (closes #11)

### DIFF
--- a/spoolman/spoolman_multi_tool.cfg
+++ b/spoolman/spoolman_multi_tool.cfg
@@ -61,7 +61,7 @@ gcode:
       SAVE_VARIABLE VARIABLE={vname} VALUE="{sid}"
     {% else %}
       #RESPOND PREFIX="🧶" MSG="Clearing spool for { vname }"
-      SAVE_VARIABLE VARIABLE={vname} VALUE=\"\"
+      SAVE_VARIABLE VARIABLE={vname} VALUE=0
     {% endif %}
   {% endfor %}
 


### PR DESCRIPTION
## Problem

When tools have no spool assigned, `SAVE_SELECTED_SPOOLS` tries to execute:

```
SAVE_VARIABLE VARIABLE={vname} VALUE=\"\"
```

Snapmaker's Klipper build catches only `ValueError` from `ast.literal_eval()`, but an empty string raises `SyntaxError` instead → printer shutdown with Error `0003-0522-0000-0002`.

Reported independently by:
- **MurphysLaw** in Snapmaker Discord (2026-05-28) — rolled back to 1.3.0
- **hadiDanial** in issue #11

## Fix

Use `VALUE=0` instead of `VALUE=\"\"`:

```jinja
{% else %}
  SAVE_VARIABLE VARIABLE={vname} VALUE=0
{% endif %}
```

**Why `VALUE=0` instead of removing the else-branch entirely:**
- `ast.literal_eval('0')` returns integer `0` — valid syntax, no crash
- `{% if sid %}` in T0–T3 macros treats `0` as falsy → `SET_ACTIVE_SPOOL` is correctly skipped for empty slots
- Correctly **clears** a previously assigned spool on disk — removing the else-branch would leave a stale value in `variables.cfg`, causing the old spool to be re-loaded on the next restart even after the physical spool was removed

## Test environment

- PAXX12 extended firmware v1.4.1
- 4 toolheads (T0–T3) with mixed spool assignment
- Spoolman on separate server

🤖 Generated with [Claude Code](https://claude.com/claude-code)