### PR TITLE
feat: SpoolLink Bridge — automatic RFID → Spoolman integration (transitional for v1.4.x)

### DIFF
--- a/spoollink_bridge/README.md
+++ b/spoollink_bridge/README.md
@@ -1,0 +1,185 @@
+# SpoolLink Bridge
+
+Automatic RFID → Spoolman integration for the Snapmaker U1 with PAXX CFW.
+
+When a filament tag is scanned by the U1's built-in RFID reader, this bridge
+automatically activates the matching spool in Spoolman — no manual selection needed.
+
+**What it does:**
+- Tag scanned by OpenRFID → webhook fires → Moonraker component looks up spool → `SET_ACTIVE_SPOOL`
+- Works with **any tag type** OpenRFID can read: Bambu/Snapmaker MiFare Classic (UID only), OpenSpool NTAG215, ELEGOO, Anycubic
+- Spoolman tracks filament consumption automatically from that point on
+
+**What it does NOT do:**
+- It does not change what the U1's touchscreen/Orca displays (that comes from the tag data itself, handled by OpenRFID's existing `success_exporter`)
+- It is not a replacement for PAXX SpoolLink (see [Migration](#migration-to-paxx-spoollink) below)
+
+---
+
+## Prerequisites
+
+- Snapmaker U1 with **PAXX CFW v1.4.1+**
+- [Spoolman](https://github.com/Donkie/Spoolman) running on your network
+- The [Spoolman multi-tool config](../spoolman/) already installed (for `SET_ACTIVE_SPOOL`, `SAVE_CURRENT_SPOOLS`, T0–T3 macros)
+- [SpoolKid](https://github.com/marko-p/SpoolKid) (iOS, TestFlight) — recommended for registering UIDs to spools
+
+---
+
+## How it works
+
+```
+RFID Tag
+   │
+   ▼
+OpenRFID (reads tag, fires webhooks)
+   │
+   ├─► success_exporter → /printer/filament_detect/set   ← existing, updates U1 GUI
+   │
+   └─► spoollink_bridge → /server/spoollink_bridge        ← NEW: this component
+            │
+            ▼
+       Spoolman lookup (by UID in extra.card_uids or lot_nr)
+            │
+            ▼
+       SET_GCODE_VARIABLE MACRO=T{ch} VARIABLE=spool_id VALUE={id}
+       SAVE_CURRENT_SPOOLS
+       SET_ACTIVE_SPOOL ID={id}
+```
+
+---
+
+## Installation
+
+### 1. Copy the Moonraker component
+
+```bash
+cp spoollink_bridge.py ~/moonraker/moonraker/components/spoollink_bridge.py
+```
+
+> **Note:** On PAXX CFW, Moonraker is at `/home/lava/moonraker/`.
+
+### 2. Add the Moonraker config
+
+Copy `moonraker_spoollink_bridge.cfg` to your Moonraker include directory:
+
+```bash
+cp moonraker_spoollink_bridge.cfg ~/printer_data/config/extended/moonraker/05_spoollink_bridge.cfg
+```
+
+Edit the file and set your Spoolman URL if it's not running on the printer itself:
+
+```ini
+[spoollink_bridge]
+spoolman_url: http://192.168.1.100:7912
+```
+
+### 3. Add the OpenRFID webhook
+
+Append the contents of `openrfid_webhook_addition.cfg` to your OpenRFID user config:
+
+```bash
+cat openrfid_webhook_addition.cfg >> /oem/printer_data/config/extended/openrfid_user.cfg
+```
+
+> **Important:** `/oem/` is the PAXX overlay filesystem.
+> Run `touch /oem/.debug` once to enable persistence across reboots.
+> All changes in `/oem/overlay/upper/` are lost on firmware updates — re-apply after updating.
+
+### 4. Reboot the printer
+
+A **full power cycle** (not just a Moonraker/Klipper restart) is required so OpenRFID picks up the new webhook config. OpenRFID runs as root and cannot be restarted as the `lava` user.
+
+### 5. Verify
+
+After reboot, check the Moonraker log:
+
+```
+grep -i spoollink ~/printer_data/logs/moonraker.log
+```
+
+Expected output:
+```
+Component (spoollink_bridge) loaded
+SpoolLink Bridge: endpoint /server/spoollink_bridge registered
+SpoolLink Bridge: extra.card_uids field already exists   ← or "created"
+```
+
+---
+
+## Registering UIDs to spools
+
+The bridge needs to know which tag UID belongs to which spool. There are two options:
+
+### Option A: SpoolKid (recommended)
+
+[SpoolKid](https://github.com/marko-p/SpoolKid) (iOS, free TestFlight beta) writes NFC tags and registers UIDs automatically.
+
+1. Open SpoolKid → select spool → tap the NFC scan icon in the edit form
+2. Hold the tag to your iPhone → UID is written to `lot_nr` in Spoolman
+3. The bridge reads `lot_nr` format: `card_uid:UID` or `card_uid:UID1,card_uid:UID2`
+
+> **Tip:** SpoolKid works with Spoolman over HTTP to private IP addresses (`http://192.168.x.x:7912`).
+> HTTP to hostnames fails on iOS due to ATS — always use the IP address.
+
+### Option B: Manual via Spoolman UI or API
+
+In the Spoolman web UI, edit a spool and set the **Card UIDs** field (`extra.card_uids`) to the tag's UID.
+
+The bridge creates this custom field automatically on first start.
+
+To find a tag's UID without SpoolKid: hold the tag to the U1 reader, then check the Moonraker log:
+```
+grep 'card UID' ~/printer_data/logs/moonraker.log | tail -5
+```
+
+Or read it from Klipper's `filament_detect` object:
+```bash
+wget -qO- 'http://localhost:7125/printer/objects/query?filament_detect' | \
+  python3 -c "import sys,json; d=json.load(sys.stdin); \
+  [print(f'ch{i}:', bytes(ch['CARD_UID']).hex().upper() if isinstance(ch['CARD_UID'], list) else ch['CARD_UID']) \
+  for i,ch in enumerate(d['result']['status']['filament_detect']['info'])]"
+```
+
+---
+
+## UID formats by tag type
+
+| Tag type | UID length | Example | Notes |
+|----------|-----------|---------|-------|
+| Bambu / Snapmaker MiFare Classic | 4 bytes | `E0BB543F` | UID only, content unreadable |
+| OpenSpool NTAG215 / NTAG216 | 7 bytes | `04DBAD28BF2A81` | Full content readable |
+| ELEGOO | 7 bytes | — | Content readable |
+
+The bridge works with all of them — only the UID matters for Spoolman lookup.
+
+---
+
+## Migration to PAXX SpoolLink
+
+PAXX SpoolLink (PR #491, coming in firmware v1.5.x) is the native version of this bridge, built directly into the firmware. Once it lands:
+
+1. Remove the `[webhook_exporter spoollink_bridge]` section from `openrfid_user.cfg`
+2. Remove `[spoollink_bridge]` from your Moonraker config
+3. Remove `spoollink_bridge.py` from the Moonraker components directory
+4. Migrate UIDs: SpoolLink uses `extra.card_uids`, SpoolKid uses `lot_nr` — check if a migration step is needed
+
+UIDs already in `extra.card_uids` (registered via the Spoolman UI) are already in the format SpoolLink expects — no migration needed for those.
+
+---
+
+## Troubleshooting
+
+**Bridge loaded but tag not recognized (`No spool found for UID ...`)**
+→ UID not registered in Spoolman. Use SpoolKid or the manual method above.
+
+**No log entries after tag scan**
+→ OpenRFID did not fire the webhook. Check that:
+- `/oem/.debug` exists (persistence enabled)
+- The webhook section is in `/oem/printer_data/config/extended/openrfid_user.cfg`
+- A full power cycle was done after adding the webhook
+
+**`Component (spoollink_bridge)` missing from Moonraker log**
+→ Config file not found. Check that `moonraker_spoollink_bridge.cfg` is in a directory included by `moonraker.conf`.
+
+**Spoolman unreachable error in log**
+→ Check `spoolman_url` in the config. On PAXX CFW, Spoolman runs on the host network, not on the printer. Use the host's IP address.

--- a/spoollink_bridge/moonraker_spoollink_bridge.cfg
+++ b/spoollink_bridge/moonraker_spoollink_bridge.cfg
@@ -1,0 +1,7 @@
+# SpoolLink Bridge — Moonraker component config
+# Place this file in: ~/printer_data/config/extended/moonraker/
+# (or any directory included via [include .../*.cfg] in moonraker.conf)
+
+[spoollink_bridge]
+# URL of your Spoolman instance
+spoolman_url: http://127.0.0.1:7912

--- a/spoollink_bridge/openrfid_webhook_addition.cfg
+++ b/spoollink_bridge/openrfid_webhook_addition.cfg
@@ -1,0 +1,11 @@
+# SpoolLink Bridge — OpenRFID webhook addition
+# Append this to: /oem/printer_data/config/extended/openrfid_user.cfg
+#
+# NOTE: /oem/ is the PAXX CFW overlay filesystem.
+# Requires data persistence: touch /oem/.debug (survives reboots, lost on firmware update)
+
+[webhook_exporter spoollink_bridge]
+event = tag_read
+method = POST
+url = http://localhost:7125/server/spoollink_bridge
+body_json_template = {"channel": {{ reader.slot }}, "card_uid": "{{ scan.uid }}"}

--- a/spoollink_bridge/spoollink_bridge.py
+++ b/spoollink_bridge/spoollink_bridge.py
@@ -1,0 +1,157 @@
+"""
+SpoolLink Bridge — Moonraker Component
+=======================================
+Bridges OpenRFID webhook events to Spoolman filament tracking on the Snapmaker U1.
+
+When an NFC/RFID tag is scanned by OpenRFID, this component:
+  1. Receives the webhook (channel + card UID)
+  2. Looks up the matching spool in Spoolman (via extra.card_uids or lot_nr)
+  3. Calls SET_ACTIVE_SPOOL to update Klipper + Spoolman tracking
+
+UID Registration (two supported formats):
+  - extra.card_uids  : preferred (SpoolLink-native, comma-separated UIDs)
+  - lot_nr           : SpoolKid app format ("card_uid:UID[,card_uid:UID2]")
+
+Forward-compatible with PAXX SpoolLink (PR #491 / v1.5.x):
+  Once the native SpoolLink firmware lands, migrate UIDs from lot_nr → extra.card_uids
+  and retire this component.
+
+Installation: see README.md
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from ..common import RequestType
+
+if TYPE_CHECKING:
+    from ..confighelper import ConfigHelper
+    from .http_client import HttpClient
+    from .klippy_apis import KlippyAPI as APIComp
+    from ..common import WebRequest
+
+log = logging.getLogger(__name__)
+
+
+class SpoolinkBridge:
+    def __init__(self, config: ConfigHelper) -> None:
+        self.server = config.get_server()
+        self._spoolman_url = config.get(
+            "spoolman_url", "http://127.0.0.1:7912"
+        ).rstrip("/")
+        self.http_client: HttpClient = self.server.lookup_component("http_client")
+        self.klippy_apis: APIComp = self.server.lookup_component("klippy_apis")
+
+        self.server.register_endpoint(
+            "/server/spoollink_bridge",
+            RequestType.POST,
+            self._handle_webhook,
+        )
+        log.info("SpoolLink Bridge: endpoint /server/spoollink_bridge registered")
+
+    async def component_init(self) -> None:
+        await self._ensure_card_uids_field()
+
+    async def _handle_webhook(self, web_request: WebRequest) -> Dict[str, Any]:
+        """Receive OpenRFID webhook: {channel: int, card_uid: str}"""
+        channel: int = web_request.get_int("channel")
+        card_uid: str = web_request.get_str("card_uid").strip().upper()
+        if not card_uid:
+            raise self.server.error("Missing card_uid", 400)
+        log.info("ch%d: card UID %s", channel, card_uid)
+        spool = await self._find_spool(card_uid)
+        if spool:
+            await self._activate_spool(channel, spool)
+        else:
+            log.warning(
+                "ch%d: no spool found for UID %s — register via Spoolman "
+                "extra.card_uids or SpoolKid app", channel, card_uid
+            )
+        return {"spool_id": spool["id"] if spool else None}
+
+    async def _find_spool(self, card_uid: str) -> Optional[dict]:
+        """Look up spool by UID. Checks extra.card_uids first, then lot_nr."""
+        uid = card_uid.upper()
+        try:
+            resp = await self.http_client.get(
+                f"{self._spoolman_url}/api/v1/spool?limit=1000",
+                enable_cache=False,
+            )
+            if resp.status_code != 200:
+                log.error("Spoolman HTTP %d", resp.status_code)
+                return None
+            spools = resp.json()
+        except Exception as e:
+            log.error("Spoolman unreachable: %s", e)
+            return None
+
+        # 1. extra.card_uids (SpoolLink-native, preferred)
+        #    Format: "UID1" or "UID1,UID2" (stored with surrounding quotes by Spoolman)
+        for spool in spools:
+            raw = (spool.get("extra") or {}).get("card_uids") or ""
+            uids = [
+                u.strip().upper()
+                for u in raw.strip().strip('"').split(",")
+                if u.strip()
+            ]
+            if uid in uids:
+                log.info("Match via extra.card_uids -> spool #%s", spool["id"])
+                return spool
+
+        # 2. lot_nr (SpoolKid app format: "card_uid:UID[,card_uid:UID2]")
+        for spool in spools:
+            for part in (spool.get("lot_nr") or "").split(","):
+                part = part.strip()
+                if (
+                    part.startswith("card_uid:")
+                    and part[len("card_uid:"):].strip().upper() == uid
+                ):
+                    log.info("Match via lot_nr -> spool #%s", spool["id"])
+                    return spool
+
+        return None
+
+    async def _activate_spool(self, channel: int, spool: dict) -> None:
+        """Update Klipper variable + Spoolman tracking for the matched spool."""
+        spool_id = spool["id"]
+        script = (
+            f"SET_GCODE_VARIABLE MACRO=T{channel} VARIABLE=spool_id VALUE={spool_id}\n"
+            f"SAVE_CURRENT_SPOOLS\n"
+            f"SET_ACTIVE_SPOOL ID={spool_id}"
+        )
+        try:
+            await self.klippy_apis.run_gcode(script)
+            log.info("ch%d: spool #%d activated", channel, spool_id)
+        except Exception as e:
+            log.error("ch%d: gcode failed: %s", channel, e)
+
+    async def _ensure_card_uids_field(self) -> None:
+        """Create the extra.card_uids custom field in Spoolman if it doesn't exist."""
+        try:
+            resp = await self.http_client.get(
+                f"{self._spoolman_url}/api/v1/field/spool",
+                enable_cache=False,
+            )
+            if resp.status_code != 200:
+                return
+            if any(f.get("key") == "card_uids" for f in resp.json()):
+                log.info("SpoolLink Bridge: extra.card_uids field already exists")
+                return
+            body = {
+                "name": "Card UIDs",
+                "field_type": "text",
+                "order": 1,
+                "default_value": json.dumps(""),
+            }
+            await self.http_client.post(
+                f"{self._spoolman_url}/api/v1/field/spool/card_uids", body=body
+            )
+            log.info("SpoolLink Bridge: created extra.card_uids field in Spoolman")
+        except Exception as e:
+            log.warning("Could not ensure card_uids field: %s", e)
+
+
+def load_component(config: ConfigHelper) -> SpoolinkBridge:
+    return SpoolinkBridge(config)


### PR DESCRIPTION
## Problem

On PAXX CFW v1.4.x, OpenRFID reads filament tags and updates the U1 GUI — but
there is no way to automatically activate the matching spool in Spoolman. Native
SpoolLink (PR #491) is merged in main but not yet in a production release.

Discussed in [Snapmaker Discord #u1-mods](https://discord.com/channels/1086575708903571536/1423454452014252165/1528014710073590013).

## Solution

A transitional Moonraker component that bridges the gap:

```
RFID Tag
   │
   ▼
OpenRFID (reads tag, fires webhooks)
   │
   ├─► success_exporter → filament_detect   ← existing, updates U1 GUI
   │
   └─► spoollink_bridge → /server/spoollink_bridge   ← this PR
            │
            ▼
       Spoolman UID lookup (extra.card_uids → lot_nr fallback)
            │
            ▼
       SET_GCODE_VARIABLE MACRO=T{ch} VARIABLE=spool_id VALUE={id}
       SAVE_CURRENT_SPOOLS
       SET_ACTIVE_SPOOL ID={id}
```

**Works with any tag type OpenRFID can read:**
- Snapmaker / Bambu MiFare Classic (UID-only, no writable tag needed)
- OpenSpool NTAG215
- ELEGOO, Anycubic

**UID lookup priority:**
1. `extra.card_uids` — native SpoolLink field, comma-separated
2. `lot_nr` — SpoolKid format (`card_uid:UID`)

## Files

| File | Purpose |
|------|---------|
| `spoollink_bridge/spoollink_bridge.py` | Moonraker component |
| `spoollink_bridge/moonraker_spoollink_bridge.cfg` | `[spoollink_bridge]` config section |
| `spoollink_bridge/openrfid_webhook_addition.cfg` | Snippet to append to `openrfid_user.cfg` |
| `spoollink_bridge/README.md` | Full installation guide, UID formats, troubleshooting |

## Migration to native SpoolLink

This bridge is intentionally minimal and designed to be removed cleanly once
PAXX v1.5.x ships with native SpoolLink:

1. Remove `[webhook_exporter spoollink_bridge]` from `openrfid_user.cfg`
2. Remove `[spoollink_bridge]` from Moonraker config
3. Remove `spoollink_bridge.py` from components
4. UIDs stored in `extra.card_uids` remain compatible — no migration needed

## Test environment

- PAXX CFW v1.4.1-paxx12-20
- Spoolman on separate server
- 4 toolheads, mixed MiFare Classic + OpenSpool NTAG215 tags
- End-to-end verified: tag scan → webhook → Spoolman lookup → `SET_ACTIVE_SPOOL` ✅